### PR TITLE
Casting to string type for reading AAC audio file

### DIFF
--- a/src/Detector/AacDetector.php
+++ b/src/Detector/AacDetector.php
@@ -25,7 +25,7 @@ final class AacDetector implements AudioDetectorInterface
         $file->fread(8);
 
         // ISO Base Media File Format, the brand "M4A " is used.
-        $brand = $file->fread(4);
+        $brand = (string)$file->fread(4);
 
         return $brand === 'M4A ' ? new AudioType(
             AudioFormat::AAC,


### PR DESCRIPTION
# Changed log
- To be consistency and it's nice to let AAC audio file cast to `string` type when reading `AAC` audio file bytes.