### PR TITLE
Add PHP-8.1 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-versions: [ '7.3', '7.4', '8.0' ]
+        php-versions: [ '7.3', '7.4', '8.0', '8.1' ]
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:

--- a/src/Detector/AiffDetector.php
+++ b/src/Detector/AiffDetector.php
@@ -23,7 +23,7 @@ final class AiffDetector implements AudioDetectorInterface
     {
         $ckID = (string)$file->fread(4);
 
-        //ckID is always 'FORM' for AIFF. If this is not the case, return null and do not check further.
+        // ckID is always 'FORM' for AIFF. If this is not the case, return null and do not check further.
         if ($ckID != 'FORM') {
             return null;
         }


### PR DESCRIPTION
# Changed log

- Add `PHP-8.1` version test.
- Fix coding style via `php-cs-fixer`. The coding style error is as follows:

```
> php-cs-fixer fix --dry-run --format=txt --verbose --diff --config=.cs.php
PHP CS Fixer 3.8.0 BerSzcz against war! by Fabien Potencier and Dariusz Ruminski.
PHP runtime: 8.0.17
Loaded config default from ".cs.php".
........F................                                         25 / 25 (100%)
Legend: ?-unknown, I-invalid file syntax (file ignored), S-skipped (cached or empty file), .-no changes, F-fixed, E-error
   1) audio-type/src/Detector/AiffDetector.php (single_line_comment_spacing)
      ---------- begin diff ----------
--- /home/runner/work/audio-type/audio-type/src/Detector/AiffDetector.php
+++ /home/runner/work/audio-type/audio-type/src/Detector/AiffDetector.php
@@ -[23](https://github.com/selective-php/audio-type/runs/5965966850?check_suite_focus=true#step:10:23),7 +23,7 @@
     {
         $ckID = (string)$file->fread(4);
 
-        //ckID is always 'FORM' for AIFF. If this is not the case, return null and do not check further.
+        // ckID is always 'FORM' for AIFF. If this is not the case, return null and do not check further.
         if ($ckID != 'FORM') {
             return null;
         }

      ----------- end diff -----------


Checked all files in 0.175 seconds, 14.000 MB memory used
```